### PR TITLE
Fixed error with array to string conversion

### DIFF
--- a/record.twig
+++ b/record.twig
@@ -64,10 +64,14 @@
                     {{ attribute(record, key)|join(", ") }}
                 </p>
 
-            {% elseif record.fieldtype(key) not in ['templateselect'] and value != "" %}
+            {% elseif record.fieldtype(key) not in ['templateselect'] and key != "templatefields" and value != "" %}
 
                 <p><strong>{{ key }}: </strong>
-                    {{ attribute(record, key) }}
+                    {% if attribute(record, key) is iterable %}
+                        {{ dump(attribute(record, key)) }}
+                    {% else %}
+                        {{ attribute(record, key) }}
+                    {% endif %}
                 </p>
 
             {%  endif %}


### PR DESCRIPTION
Fix for error that came up on newer Bolt versions:

An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Object of class Bolt\Legacy\Content could not be converted to string") in "record.twig" at line 69.